### PR TITLE
Open Source Summit 2017 - 2017.09.11-13 - USA, Los Angeles

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ List sorted by CFP end date descending (oldest and probably already finished las
 |---------|-----------------|---------------|------|----------|----------|
 | 2017.06.30 | 2017.11.09-11 | India, Bangalore | [Functional Conf](http://functionalconf.com/) | [here](http://functionalconf.com/speaker.html) | Functional Programming |
 | 2017.05.17 | 2017.10.20-21 | UAE, Dubai | [Codemotion Dubai](http://dubai2017.codemotionworld.com/) | [here](http://speaker.codemotionworld.com) | Big Data, DevOps, IoT, CI, Frontend, Backend, ... |
+| 2016.05.06 | 2017.09.11-13 | USA, Los Angeles | [Open Source Summit](http://events.linuxfoundation.org/events/open-source-summit-north-america) | [here](http://events.linuxfoundation.org/events/open-source-summit-north-america/program/cfp) | DevOps, IoT, Security, Cloud, ... |
 | 2017.05.01 | 2017.06.19-21 | Spain, Barcelona | [JBCNConf](http://www.jbcnconf.com/2017/) | [here](http://www.jbcnconf.com/2017/#callforpapers) | Java, JVM, Open Source|
 | ? | 2017.05.25 | Poland, Warszawa | [Code Europe](https://www.codeeurope.pl/en) | [here](https://www.codeeurope.pl/en) | Backend/Frontend, Mobile, Big Data |
 | ? | 2017.05.23 | Poland, Wrocław | [Code Europe](https://www.codeeurope.pl/en) | [here](https://www.codeeurope.pl/en) | Backend/Frontend, Mobile, Big Data |


### PR DESCRIPTION
Added Open Source Summit.

LinuxCon, ContainerCon, CloudOpen and the new Community Leadership Conference combine under one umbrella name in 2017 - Open Source Summit.