### PR TITLE
JAX (@jaxcon  #jax2018) - 2018.04.24-26 - Mainz, Germany

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ List sorted by CFP end date descending (oldest and probably already finished las
 | 2017.12.10 | 2018.03.01-02 | Helsinki, Finland | [ngVikings 2018](https://ngvikings.org/) | [here](https://docs.google.com/forms/d/e/1FAIpQLSePYV6ek4ixXuGxmnImQnhBRaQ7g2tmmhdOOo1dBS2_R1iK0Q/viewform) | Angular, Web, Mobile, ...|
 | 2017.12.01 | 2018.06.07-08 | Tallinn, Estonia | [GeekOut](https://2018.geekout.ee/) | [here](https://www.papercall.io/geekout2018) | Java, Web, Big Data, Architecture, ...|
 | 2017.12.01 | 2018.03.03 | Salzburg, Austria | [.concat()](https://2018.conc.at/) | [here](https://2018.conc.at/#cfp) | Web, UX, ...|
+| 2017.11.15 | 2018.04.24-26 | Mainz, Germany | [Jax 2018](https://jax.de) | [here](https://callforpapers.sandsmedia.com) | Java, JVM languages, Agile, Architecture,..|
 | 2017.11.15 | 2018.03.08 | Zürich, Switzerland | [Voxxed Days Zürich](https://voxxeddays.com/zurich/) | [here](https://cfp-vdz.exteso.com/) | JVM, BigData, Mobile, ...|
 | 2017.11.01 | 2018.01.24-27 | Grenoble, France | [SnowCamp.io](http://snowcamp.io) | [here](https://snowcamp.cfp.io/) | Languages & Framework, Web, Mobile, Cloud, DevOps, IoT, ...  |
 | 2017.10.30 | 2018.02.22-23 | Kraków, Poland | [Lambda Days](http://www.lambdadays.org) | [here](https://eventil.com/events/lambda-days-2018/submissions/proposal/step1) | Scala, Erlang, Haskell, ... |


### PR DESCRIPTION
Just received this e-mail:

> Dear JAX Speakers, friends and everyone interested!
> 
> with this e-mail we’d like to invite you to submit your session and
> workshop proposals for our next JAX conference. We are aware that we
> are a bit late and excuse for the shortened submission period. JAX
> 2018 will take place in Mainz, Germany, from 23 – 27 April 2018 and
> like previously, we will offer a broad spectrum of topics, which you
> can find below.
> 
> Deadline for submissions is 15 November 2018. 
> We are looking forward to receiving your ideas and if you have any
> questions or queries please do not hesitate to contact:
> 
> Olivia Altenhövel - oaltenhoevel@sandsmedia.com
> Sebastian Meyen - smeyen@sandsmedia.com
> 
> We hope you enjoy the first days of autumn.
> 
> Best,
> the JAX Team
> 
> ##########################
> 
> JAX 2018 - overview
> 
> * Date: 23– 27 April 2018
> * Location: Rheingoldhalle, Mainz
> * Main Conference: 24– 26 April 2018
> * Workshop Days: 23 & 27 April 2018
> * Deadline for submissions: 15 November 2017
> * Call for Papers:
> http://scnem.com/goto.php?l=i9zqil.1psb719,u=3a6a04db8f9b82b7be0c7037d26bc2ee,n=bddtt.dis6fe,art_id=bddtt.dis6fe
> 
> ####################################
> 
> JAX 2018 topics:
> 
> - Agile & Culture
> - Big Data & Machine Learning
> - Cloud, Serverless & Container
> - Performance & Security
> - Digital Transformation & Innovation
> - DevOps & Continuous Delivery
> - Microservices
> - Serverside & Enterprise Java
> - Software Architecture
> - Web Development & JavaScript
> - Core Java & JVM Languages
> 
> *****
> 