### PR TITLE
Fix typo in Devoxx Ukraine's date

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ List sorted by CFP end date descending (oldest and probably already finished las
 | 2019.09.01 | 2019.11.21-23 | Ljubljana, Slovenia | [BeeScala](https://www.bee-scala.org/) | [here](https://bee-scala.org/forms/1) | Scala, Big Data, FP, JVM |
 | 2019.08.30 | 2019.10.25 | Luxembourg, Luxembourg | [BSides Luxembourg 2019](https://bsideslux.lu) | [here](https://docs.google.com/forms/d/e/1FAIpQLSedV98yYXovhDuWBSBZbZTv89Z-rbv1jLn6-_5kygxJfmEEAA/viewform) | Information Security, Privacy, Incident Response, Digital Forensics |
 | 2019.08.25 | 2019.10.30-31 | Ede, Netherlands | [J-Fall 2019](https://jfall.nl) | [here](https://www.nljugcfp.nl) | Java, Cloud, Enterprise, Alternative JVM Languages, Methodology & Culture, Web, Mobile, Big Data & Machine Learning, Security |
-| 2018.07.23 | 2018.11.01-02 | Kiev, Ukraine | [Devoxx Ukraine](https://devoxx.org.ua/) | [here](https://dvua19.cfp.dev/#/) | Cloud, Web, JVM, Big Data, Mobile |
+| 2019.07.23 | 2019.11.01-02 | Kiev, Ukraine | [Devoxx Ukraine](https://devoxx.org.ua/) | [here](https://dvua19.cfp.dev/#/) | Cloud, Web, JVM, Big Data, Mobile |
 | 2019.07.15 | 2019.10.25-26 | Budapest, Hungary | [Hacktivity](https://www.hacktivity.com) | [here](https://www.hacktivity.com/call-for-papers) | Computer Security, Cyber Security, Hacking, IoT |
 | 2019.06.30 | 2019.10.29-31 | Lyon, France | [scala.io](https://scala.io) | [here](https://www.papercall.io/scalaio-2019) | Scala, Functional Programming, ... |
 | 2019.06.30 | 2019.10.30-11.01 | Prague, Czech Republic | [ReactiveConf](https://reactiveconf.com) | [here](https://www.papercall.io/goreactive) | JavaScript |


### PR DESCRIPTION
The conference is in 2019, not 2018.